### PR TITLE
README: fix link to krobot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kotlin-Robot - DSL based kotlin code generation
 Kotlin-Robot helps you with generating new Kotlin files programmatically, for example in annotation processors.
-There is a complete rewrite of this library named [https://github.com/NKb03/krobot](krobot), 
+There is a complete rewrite of this library named [krobot](https://github.com/NKB03/krobot/), 
 which you are advised to use instead of this one.
 
 ## Using Kotlin-Robot


### PR DESCRIPTION
The link `[https://github.com/NKb03/krobot](krobot)` didn't work [https://github.com/NKb03/krobot](krobot) it links to a relative URL :)